### PR TITLE
GitHub is not a VCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,5 +121,5 @@ The service can be launched running the following command:
 
 ## Notes
 
-- If you are using GitHub as CVS you can take advantage of GitHub Actions.
+- If you are using GitHub you can take advantage of GitHub Actions.
   The project contains configured workflows in `.github` directory. 


### PR DESCRIPTION
Calling GitHub a VCS is probably not okay, it's probably a Git and something else hoster (Git is a (D)VCS).

Simplify the sentence to avoid saying that.
