### PR TITLE
Relax on: criteria to run on each pushes

### DIFF
--- a/.github/workflows/check_markdown.yml
+++ b/.github/workflows/check_markdown.yml
@@ -1,7 +1,7 @@
 name: Check Markdown documents
 
 on:
-  pull_request:
+  push:
     paths:
       - '**.md'
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,10 +1,7 @@
 name: Java CI/CD with Gradle
 
 on:
-  pull_request:
   push:
-    branches:
-      - main
 
 jobs:
   build:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,13 +2,6 @@ name: Lint Code Base
 
 on:
   push:
-    branches:
-      - develop
-      - main
-    paths:
-      - '**/openapi/*.yaml'
-      - '.github/workflows/linter.yml'
-  pull_request:
     paths:
       - '**/openapi/*.yaml'
       - '.github/workflows/linter.yml'


### PR DESCRIPTION
Instead of inconsistently run (most) of the GitHub Actions only on `main` or `develop` or during PRs run them on each pushes.

This should hopefully avoid to not run the GitHub Actions on possible repositories clones that uses different branches than the ones listed in the GitHub Actions workflow (i.e. force running them anyway!).
